### PR TITLE
Replace hardcoded python version with actual

### DIFF
--- a/tasks/pips/pip.yml
+++ b/tasks/pips/pip.yml
@@ -11,7 +11,7 @@
   become: true
   easy_install:
     name: pip
-    executable: "/usr/bin/scl enable python33 -- easy_install"
+    executable: "/usr/bin/scl enable {{ item.python_ver }} -- easy_install"
   when: (scl_python_ver_result.stat.exists)
 
 - name: "Install PIP: {{ item.name }} for Python: {{ item.python_ver }}"


### PR DESCRIPTION
Solve error when using version other than python33: "Unable to open /etc/scl/conf/python33!\n"
